### PR TITLE
♻️ Refactor: City endpoints

### DIFF
--- a/backend/locations/models.py
+++ b/backend/locations/models.py
@@ -28,6 +28,7 @@ class Theater(models.Model):
     class Meta:
         verbose_name_plural = "Theaters"
         ordering = ["city__name", "name"]
+        unique_together = ("name", "city")
 
     def save(self, *args, **kwargs):
         """

--- a/backend/locations/serializers.py
+++ b/backend/locations/serializers.py
@@ -36,6 +36,39 @@ class CityUpdateSerializer(serializers.ModelSerializer):
         fields = ["name", "address"]
 
 
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # 
+# Theater
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+class TheaterCompleteSerializer(serializers.ModelSerializer):
+    """
+    Contains all fields. ForeignKey City is represented by city_name.
+    """
+    city_name = serializers.CharField(source="city.name")
+    class Meta:
+        model = Theater
+        fields = ["id", "name", "city_name", "rows", "columns", "created_at", "updated_at"]
+
+class TheaterCreateSerializer(serializers.ModelSerializer):
+    """
+    Contains all editable fields. Must introduce city name.
+    """
+    city = serializers.SlugRelatedField(
+        many=False, slug_field="name", queryset=City.objects.all()
+    )
+    class Meta:
+        model = Theater
+        fields = ["name", "city", "rows", "columns"]
+
+class TheaterUpdateSerializer(serializers.ModelSerializer):
+    """
+    Contains all editable fields, except city.
+    """
+    class Meta:
+        model = Theater
+        fields = ["name", "rows", "columns"]
+
+
 # Other
 class CitySerializer(serializers.ModelSerializer):
     class Meta:
@@ -49,16 +82,6 @@ class TheaterSerializer(serializers.ModelSerializer):
     class Meta:
         model = Theater
         fields = ["id", "name", "city", "rows", "columns"]
-
-
-class TheaterCreateSerializer(serializers.ModelSerializer):
-    city = serializers.SlugRelatedField(
-        many=False, slug_field="name", queryset=City.objects.all()
-    )
-
-    class Meta:
-        model = Theater
-        fields = ["name", "city", "rows", "columns"]
 
 
 class SeatSerializer(serializers.ModelSerializer):

--- a/backend/locations/tests/conftest.py
+++ b/backend/locations/tests/conftest.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import Group, User
 import pytest
 
 # App
-from locations.models import City
+from locations.models import City, Theater
 
 # Write your fixtures here.
 
@@ -40,3 +40,18 @@ def staff_user():
 @pytest.fixture
 def normal_user():
     return User.objects.create_user(username="user", password="test123")
+
+@pytest.fixture
+def theaters_list():
+    city = City.objects.create(name="Berlin", address="Street Berlin")
+    return Theater.objects.bulk_create([
+        Theater(name="Room 1", city=city, rows=1, columns=2),
+        Theater(name="Room 2", city=city, rows=3, columns=4),
+        Theater(name="Room 3", city=city, rows=5, columns=6),
+        Theater(name="Room 4", city=city, rows=7, columns=8),
+    ])
+
+@pytest.fixture
+def theater_room_berlin():
+    city = City.objects.create(name="Berlin", address="Street Berlin")
+    return Theater.objects.create(name="Room", city=city, rows=2, columns=4)

--- a/backend/locations/tests/test_serializers.py
+++ b/backend/locations/tests/test_serializers.py
@@ -7,6 +7,10 @@ from ..serializers import (
     CityPartialSerializer,
     CityCompleteSerializer,
     CityUpdateSerializer,
+    # Theater
+    TheaterCompleteSerializer,
+    TheaterCreateSerializer,
+    TheaterUpdateSerializer,
 )
 
 # Create your tests here.
@@ -67,3 +71,53 @@ def test_city_update_serializer(cities_list):
     assert data[2]["address"] == "Street Baku"
     assert data[3]["name"] == "Belgrade"
     assert data[3]["address"] == "Street Belgrade"
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # 
+# Theater
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+@pytest.mark.django_db
+def test_theater_complete_serializer(theaters_list):
+    serializer = TheaterCompleteSerializer(theaters_list, many=True)
+    data = serializer.data
+
+    assert len(data) == 4
+
+    assert "id" in data[0]
+    assert "created_at" in data[0]
+    assert data[0]["name"] == "Room 1"
+    assert data[0]["city_name"] == "Berlin"
+    assert data[0]["rows"] == 1
+    assert data[0]["columns"] == 2
+    assert "id" in data[2]
+    assert "created_at" in data[2]
+    assert data[2]["name"] == "Room 3"
+    assert data[2]["city_name"] == "Berlin"
+    assert data[2]["rows"] == 5
+    assert data[2]["columns"] == 6
+
+
+@pytest.mark.django_db
+def test_theater_create_serializer(theater_room_berlin):
+    serializer = TheaterCreateSerializer(theater_room_berlin)
+    data = serializer.data 
+
+    assert "id" not in data
+    assert "created_at" not in data
+    assert data["name"] == "Room"
+    assert data["city"] == "Berlin"
+    assert data["rows"] == 2
+    assert data["columns"] == 4
+
+@pytest.mark.django_db
+def test_theater_update_serializer(theater_room_berlin):
+    serializer = TheaterUpdateSerializer(theater_room_berlin)
+    data = serializer.data
+
+    assert "id" not in data
+    assert "created_at" not in data
+    assert data["name"] == "Room"
+    assert "city" not in data
+    assert data["rows"] == 2
+    assert data["columns"] == 4

--- a/backend/locations/tests/test_urls.py
+++ b/backend/locations/tests/test_urls.py
@@ -6,6 +6,9 @@ from ..views import (
     # City
     CityListCreateView,
     CityUpdateDestroyView,
+    # Theater
+    TheaterListCreateView,
+    TheaterUpdateDestroyView,
 )
 
 # Write your tests here.
@@ -33,3 +36,28 @@ def test_city_update_destroy_resolves():
 
 def test_city_update_destroy_reverse():
     assert reverse("update-delete-cities", args=[1]) == "/api/v1/locations/cities/1/"
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# TheaterListCreateView
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+def test_theater_list_create_resolves():
+    match = resolve("/api/v1/locations/theaters/")
+    assert match.func.view_class == TheaterListCreateView
+
+def test_theater_list_create_reverse():
+    assert reverse("create-read-theaters") == "/api/v1/locations/theaters/"
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# TheaterUpdateDestroyView
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+def test_theater_update_destroy_resolves():
+    match = resolve("/api/v1/locations/theaters/1/")
+    assert match.func.view_class == TheaterUpdateDestroyView
+
+def test_theater_update_destroy_reverse():
+    assert reverse("update-delete-theaters", args=[1]) == "/api/v1/locations/theaters/1/"
+

--- a/backend/locations/tests/test_views.py
+++ b/backend/locations/tests/test_views.py
@@ -9,7 +9,7 @@ from rest_framework import status
 import pytest
 
 # App
-from ..models import City
+from ..models import City, Theater
 
 # Write your tests here.
 
@@ -179,3 +179,176 @@ def test_city_delete_as_staff(staff_user, city_london):
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert not City.objects.filter(id=city_london.id).exists()
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # 
+# Theater - LIST
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+@pytest.mark.django_db
+def test_theater_list_as_visitor(theater_room_berlin):
+    client = APIClient()
+    url = reverse("create-read-theaters")
+    response = client.get(url)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_theater_list_as_normal_user(theater_room_berlin, normal_user):
+    client = APIClient()
+    client.force_authenticate(user=normal_user)
+    url = reverse("create-read-theaters")
+    response = client.get(url)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_theater_list_as_manager(theater_room_berlin, manager_user):
+    client = APIClient()
+    client.force_authenticate(user=manager_user)
+    url = reverse("create-read-theaters")
+    response = client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    assert len(response.data) == 1
+    assert "id" in response.data[0] 
+    assert "name" in response.data[0] 
+    assert "city_name" in response.data[0]
+    assert "rows" in response.data[0] 
+    assert "columns" in response.data[0] 
+    assert "created_at" in response.data[0] 
+    assert "updated_at" in response.data[0] 
+
+
+@pytest.mark.django_db
+def test_theater_list_as_staff(theater_room_berlin, staff_user):
+    client = APIClient()
+    client.force_authenticate(user=staff_user)
+    url = reverse("create-read-theaters")
+    response = client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    assert len(response.data) == 1
+    assert "id" in response.data[0] 
+    assert "name" in response.data[0] 
+    assert "city_name" in response.data[0]
+    assert "rows" in response.data[0] 
+    assert "columns" in response.data[0] 
+    assert "created_at" in response.data[0] 
+    assert "updated_at" in response.data[0]
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # 
+# Theater - CREATE
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+@pytest.mark.django_db
+def test_theater_create_as_visitor(city_london):
+    client = APIClient()
+    url = reverse("create-read-theaters")
+    response = client.post(url, data={"name": "Room", "city": city_london.name, "rows": 2, "columns": 3})
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_theater_create_as_normal_user(normal_user, city_london):
+    client = APIClient()
+    client.force_authenticate(user=normal_user)
+    url = reverse("create-read-theaters")
+    response = client.post(url, data={"name": "Room", "city": city_london.name, "rows": 2, "columns": 3})
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_theater_create_as_staff(staff_user, city_london):
+    client = APIClient()
+    client.force_authenticate(user=staff_user)
+    url = reverse("create-read-theaters")
+    response = client.post(url, data={"name": "Room", "city": city_london.name, "rows": 2, "columns": 3})
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+@pytest.mark.django_db
+def test_theater_create_as_manager(manager_user, city_london):
+    client = APIClient()
+    client.force_authenticate(user=manager_user)
+    url = reverse("create-read-theaters")
+    response = client.post(url, data={"name": "Room", "city": city_london.name, "rows": 2, "columns": 3})
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+@pytest.mark.django_db
+def test_theater_create_as_manager_no_field(manager_user):
+    client = APIClient()
+    client.force_authenticate(user=manager_user)
+    url = reverse("create-read-theaters")
+    response = client.post(url, data={"name": "Room", "rows": 2})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_theater_create_as_manager_invalid_field(manager_user):
+    client = APIClient()
+    client.force_authenticate(user=manager_user)
+    url = reverse("create-read-theaters")
+    response = client.post(url, data={"name": "Room", "country": "France"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # 
+# Theater - PATCH
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+@pytest.mark.django_db
+def test_theater_patch_as_normal_user(normal_user, theater_room_berlin):
+    client = APIClient()
+    client.force_authenticate(user=normal_user)
+    url = reverse("update-delete-theaters", kwargs={"id": theater_room_berlin.id})
+    response = client.patch(url, data={"name": "Updated"})
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_theater_patch_as_manager(manager_user, theater_room_berlin):
+    client = APIClient()
+    client.force_authenticate(user=manager_user)
+    url = reverse("update-delete-theaters", kwargs={"id": theater_room_berlin.id})
+    response = client.patch(url, data={"name": "Updated"})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["name"] == "Updated"
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # 
+# Theater - DELETE
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+@pytest.mark.django_db
+def test_theater_delete_as_visitor(theater_room_berlin):
+    client = APIClient()
+    url = reverse("update-delete-theaters", kwargs={"id": theater_room_berlin.id})
+    response = client.delete(url)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_theater_delete_as_staff(staff_user, theater_room_berlin):
+    client = APIClient()
+    client.force_authenticate(user=staff_user)
+    url = reverse("update-delete-theaters", kwargs={"id": theater_room_berlin.id})
+    response = client.delete(url)
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert not Theater.objects.filter(id=theater_room_berlin.id).exists()

--- a/backend/locations/urls.py
+++ b/backend/locations/urls.py
@@ -5,6 +5,9 @@ from .views import (
     # City
     CityListCreateView,
     CityUpdateDestroyView,
+    # Theater
+    TheaterListCreateView,
+    TheaterUpdateDestroyView,
 )
 
 # Create your urls here.
@@ -13,4 +16,7 @@ urlpatterns = [
     # City
     path("cities/", CityListCreateView.as_view(), name="create-read-cities"),
     path("cities/<int:id>/", CityUpdateDestroyView.as_view(), name="update-delete-cities"),
+    # Theater
+    path("theaters/", TheaterListCreateView.as_view(), name="create-read-theaters"),
+    path("theaters/<int:id>/", TheaterUpdateDestroyView.as_view(), name="update-delete-theaters"),
 ]

--- a/backend/locations/urls_alpha.py
+++ b/backend/locations/urls_alpha.py
@@ -2,23 +2,11 @@ from django.urls import path
 
 # App
 from .views import (
-    TheaterListView,
-    TheaterRetrieveView,
-    TheaterCreateView,
-    TheaterUpdateDestroy,
     SeatListView,
 )
 # Create your urls here.
 
 
 urlpatterns = [
-    path("theaters/", TheaterListView.as_view(), name="theater-list"),
-    path("theaters/<int:pk>/", TheaterRetrieveView.as_view(), name="theater-retrieve"),
-    path("theaters/create/", TheaterCreateView.as_view(), name="theater-create"),
-    path(
-        "theaters/staff/<int:pk>/",
-        TheaterUpdateDestroy.as_view(),
-        name="theater-update-delete",
-    ),
     path("seats/", SeatListView.as_view(), name="seat-list"),
 ]

--- a/backend/locations/views.py
+++ b/backend/locations/views.py
@@ -19,9 +19,12 @@ from .serializers import (
     CityPartialSerializer,
     CityCompleteSerializer,
     CityUpdateSerializer,
+    # Theater
+    TheaterCompleteSerializer,
+    TheaterCreateSerializer,
+    TheaterUpdateSerializer,
     # Other
     TheaterSerializer,
-    TheaterCreateSerializer,
     SeatSerializer,
 )
 from users.permissions import IsManager
@@ -66,7 +69,7 @@ class CityUpdateDestroyView(
 ):
     """
     Only available to staff or 'Manager' group.\n
-    PATCH: update City object (name, address).\n
+    PATCH: partial update City object (name, address).\n
     DELETE: delete City object.\n
     """
 
@@ -78,6 +81,52 @@ class CityUpdateDestroyView(
     def patch(self, request, *args, **kwargs):
         return super().partial_update(request, *args, **kwargs)
 
+    def delete(self, request, *args, **kwargs):
+        return super().destroy(request, *args, **kwargs)
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # 
+# Theater
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+@extend_schema(tags=["v1 - Theaters"])
+class TheaterListCreateView(generics.ListCreateAPIView):
+    """
+    Only available to staff or 'Manager' group.\n
+    GET: list all Theater objects, with complete fields on response.\n
+    POST: create Theater object.\n
+    """
+
+    queryset = Theater.objects.select_related("city")
+    serializer_class = TheaterCompleteSerializer
+    permission_classes = [IsManager]
+
+    def get_serializer_class(self):
+        if self.request.method == "POST":
+            return TheaterCreateSerializer
+        return TheaterCompleteSerializer
+
+
+@extend_schema(tags=["v1 - Theaters"])
+class TheaterUpdateDestroyView(
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+    generics.GenericAPIView
+):
+    """
+    Only available to staff or 'Manager' group.\n
+    PATCH: partial update Theater object (name, rows, columns).\n
+    DELETE: delete Theater object.\n
+    """
+
+    queryset = Theater.objects.all()
+    serializer_class = TheaterUpdateSerializer
+    permission_classes = [IsManager]
+    lookup_field = "id"
+
+    def patch(self, request, *args, **kwargs):
+        return super().partial_update(request, *args, **kwargs)
+    
     def delete(self, request, *args, **kwargs):
         return super().destroy(request, *args, **kwargs)
 

--- a/frontend/src/components/page-components/StaffPage/TheaterManagement.jsx
+++ b/frontend/src/components/page-components/StaffPage/TheaterManagement.jsx
@@ -58,14 +58,14 @@ const TheaterManagement = () => {
   // Read theaters
   const columns = [
     { key: "id", title: "ID" },
-    { key: "city", title: "City" },
+    { key: "city_name", title: "City" },
     { key: "name", title: "Name" },
     { key: "r-c", title: "Rows-Columns" }
   ]
   const renderCell = (theater, column) => {
     switch (column.key) {
       case "id": return theater.id
-      case "city": return theater.city.name
+      case "city_name": return theater.city_name
       case "name": return theater.name
       case "r-c": return `R${theater.rows}-C${theater.columns}`
     }

--- a/frontend/src/hooks/locations/theater/staff/useCreateTheater.jsx
+++ b/frontend/src/hooks/locations/theater/staff/useCreateTheater.jsx
@@ -18,13 +18,13 @@ export const useCreateTheater = () => {
     try {
       const response = await theaterService.createTheater(name, city, rows, columns)
       setData(response.data)
-      alert(`✅ Theater ${name} created!`)
-      console.log("Create Theater successful:", response.data)
+      alert(`✅ Theater ${name}, ${city} created!`)
+      console.log("Staff - Create Theater successful:", response.data)
       return response.data
     } catch (error) {
       setError("Something went wrong while creating theater. Please try again.")
-      alert(`❌ Theater ${name} do not created!`)
-      console.error("Create Theater unsuccessful:", error)
+      alert(`❌ Theater ${name}, ${city} not created!`)
+      console.error("Staff - Create Theater unsuccessful:", error)
       return null
     } finally {
       setLoading(false)

--- a/frontend/src/hooks/locations/theater/staff/useDeleteTheater.jsx
+++ b/frontend/src/hooks/locations/theater/staff/useDeleteTheater.jsx
@@ -19,12 +19,12 @@ export const useDeleteTheater = () => {
       const response = await theaterService.deleteTheater(theaterId)
       setData(response.data)
       alert(`✅ Theater deleted!`)
-      console.log("Delete Theater successful:", response.data)
+      console.log("Staff - Delete Theater successful:", response.data)
       return true
     } catch (error) {
       setError("Something went wrong while deleting theater. Please try again.")
-      alert(`❌ Theater do not deleted!`)
-      console.error("Delete Theater unsuccessful:", error)
+      alert(`❌ Theater not deleted!`)
+      console.error("Staff - Delete Theater unsuccessful:", error)
       return false
     } finally {
       setLoading(false)

--- a/frontend/src/hooks/locations/theater/staff/useReadTheaters.jsx
+++ b/frontend/src/hooks/locations/theater/staff/useReadTheaters.jsx
@@ -1,14 +1,15 @@
 // React, dependencies & packages
-import { theaterService } from "@/services/locations/theaterService"
 import { useEffect, useState } from "react"
 
 // App
-
+import { useAuthContext } from "@/contexts/AuthContext"
+import { theaterService } from "@/services/locations/theaterService"
 
 // Components here
 
 
 export const useReadTheaters = () => {
+  const { accessToken } = useAuthContext()
   const [theaters, setTheaters] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -19,10 +20,10 @@ export const useReadTheaters = () => {
       setError(null)
       const response = await theaterService.readTheaters()
       setTheaters(response.data)
-      console.log("Read Theaters successful:", response.data)
+      console.log("Staff - Read Theaters successful:", response.data)
     } catch (error) {
-      setError("Theaters cannot be loaded. Please try again!")
-      console.error('Read Theaters unsuccessful:', error)
+      setError("Something went wrong while reading theaters. Please try again.")
+      console.error('Staff - Read Theaters unsuccessful:', error)
     } finally {
       setLoading(false)
     }
@@ -30,7 +31,7 @@ export const useReadTheaters = () => {
     
   useEffect(() => {
     readTheaters()
-  }, [])
+  }, [accessToken])
 
   return { theaters, loading, error, refetch: readTheaters }
 }

--- a/frontend/src/hooks/locations/theater/staff/useUpdateTheater.jsx
+++ b/frontend/src/hooks/locations/theater/staff/useUpdateTheater.jsx
@@ -19,12 +19,12 @@ export const useUpdateTheater = () => {
       const response = await theaterService.updateTheater(theaterId, name, rows, columns)
       setData(response.data)
       alert(`✅ Theater updated!`)
-      console.log("Update Theater successful:", response.data)
+      console.log("Staff - Update Theater successful:", response.data)
       return response.data
     } catch (error) {
       setError("Something went wrong while updating theater. Please try again.")
-      alert(`❌ Theater ${name} do not updated!`)
-      console.error("Update Theater unsuccessful:", error)
+      alert(`❌ Theater ${name} not updated!`)
+      console.error("Staff - Update Theater unsuccessful:", error)
       return null
     } finally {
       setLoading(false)

--- a/frontend/src/services/locations/theaterService.jsx
+++ b/frontend/src/services/locations/theaterService.jsx
@@ -5,18 +5,17 @@ import api from "../Api"
 
 
 export const theaterService = {
-  // Staff: CRUD
-  createTheater: (name, city, rows, columns) => api.post(`/locations/theaters/create/`, { 
+  readTheaters: () => api.get(`/v1/locations/theaters/`),
+  createTheater: (name, city, rows, columns) => api.post(`/v1/locations/theaters/`, { 
     name: name, 
     city: city, 
     rows: rows,
     columns: columns 
   }),
-  readTheaters: () => api.get(`/locations/theaters/`),
-  updateTheater: (theaterId, name, rows, columns) => api.patch(`/locations/theaters/staff/${theaterId}/`, { 
+  updateTheater: (theaterId, name, rows, columns) => api.patch(`/v1/locations/theaters/${theaterId}/`, { 
     name: name, 
     rows: rows, 
     columns: columns
    }),
-  deleteTheater: (theaterId) => api.delete(`/locations/theaters/staff/${theaterId}/`),
+  deleteTheater: (theaterId) => api.delete(`/v1/locations/theaters/${theaterId}/`),
 }


### PR DESCRIPTION
On  refactor/theatersEndpoints branch:
- Theater API endpoints now have:
2 urls: GET & POST /theaters/ and PATCH & DELETE /theaters/:id/
2 views: TheaterListCreateView and TheaterUpdateDestroyView
3 serializers: TheaterCompleteSerializer (all fields, ForeignKey City is represented as city_name), TheaterCreateSerializer (all editable fields, city expects city name), TheaterUpdateSerializer (name, rows, columns fields)
- Write tests for the above mentioned components
- Update frontend (theaterManagement component, theaterService & hooks) to integrate endpoints